### PR TITLE
Update Template.php

### DIFF
--- a/plugin/app/code/local/MJ/Customsmtp/Model/Email/Template.php
+++ b/plugin/app/code/local/MJ/Customsmtp/Model/Email/Template.php
@@ -66,7 +66,14 @@ class MJ_Customsmtp_Model_Email_Template extends Mage_Core_Model_Email_Template 
         }
 
         else {
-            $mail->addTo($Mail->getToEmail(), '=?utf-8?B?' . base64_encode($Mail->getToName()) . '?=');
+        	
+        	$toName = $Mail->getToName();
+			
+			if (is_array($toName)) {
+				$toName = $toName[0];
+			}
+			
+            $mail->addTo($Mail->getToEmail(), '=?utf-8?B?' . base64_encode($toName) . '?=');
         }
 
         $mail->setFrom($Mail->getFromEmail(), $Mail->getFromName());


### PR DESCRIPTION
Fix issue Warning when $Mail->getToName(); is an array 

Warning: base64_encode() expects parameter 1 to be string, array given  in magento\app\code\local\MJ\Customsmtp\Model\Email\Template.php on line 64